### PR TITLE
Add a trimmed down s3box

### DIFF
--- a/s3box/s3_helpers.go
+++ b/s3box/s3_helpers.go
@@ -1,0 +1,94 @@
+package s3box
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+const aesAlgo = "AES256" // Algo used for server-side encryption.
+
+// Modularize functions for testing
+var (
+	getRegionForBucket func(string) (string, error)
+	writeToS3          func(s3Handler *s3.S3, bucket string, fileKey string, data []byte) error
+)
+
+// getRegionForBucketProd looks up the region name for the given bucket
+func getRegionForBucketProd(name string) (string, error) {
+	// Any region will work for the region lookup, but the request MUST use PathStyle
+	config := aws.NewConfig().WithRegion("us-west-1").WithS3ForcePathStyle(true)
+	session := session.New()
+	client := s3.New(session, config)
+	params := s3.GetBucketLocationInput{
+		Bucket: aws.String(name),
+	}
+	resp, err := client.GetBucketLocation(&params)
+	if err != nil {
+		return "", fmt.Errorf("Failed to get location for bucket '%s', %s", name, err)
+	}
+	if resp.LocationConstraint == nil {
+		// "US Standard", returns an empty region. So return any region in the US
+		return "us-east-1", nil
+	}
+	return *resp.LocationConstraint, nil
+}
+
+// uploadToS3 streams readers to an encrypted s3 file.
+func uploadToS3(s3Handler *s3.S3, bucket, fileKey string, data io.Reader) error {
+	uploader := s3manager.NewUploaderWithClient(s3Handler)
+	_, err := uploader.Upload(&s3manager.UploadInput{
+		Body:                 data,
+		Bucket:               aws.String(bucket),
+		Key:                  aws.String(fileKey),
+		ServerSideEncryption: aws.String(aesAlgo),
+	})
+	return err
+}
+
+// compressAndWriteBytesToS3 creates a gzip compression for writing to s3.
+//
+// The mechanics of this function deserve some attention. AWSs upload requires a reader
+// and our goal is to compress out bytes in gzip format and stream them to s3.
+// We accomplish this by creating a reader/writer pair returned from io.Pipe().
+// To correctly use this pair we need the reader to be hooked up to a sync before writing any data,
+// thus we set off two go routines, one for hooking up the source (the data to write) and another
+// for establishing the sync (the destination s3 file).
+func compressAndWriteBytesToS3(s3Handler *s3.S3, bucket, key string, data []byte) error {
+	var wg sync.WaitGroup
+	var writeErr error
+	var streamErr error
+	wg.Add(2)
+	reader, writer := io.Pipe()
+
+	// Source initiation
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		gzipWriter := gzip.NewWriter(writer)
+		defer writer.Close()
+		defer gzipWriter.Close()
+		_, writeErr = gzipWriter.Write(data)
+	}(&wg)
+
+	// Sink initiation
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		streamErr = uploadToS3(s3Handler, bucket, key, reader)
+	}(&wg)
+	wg.Wait()
+	if writeErr != nil {
+		return writeErr
+	}
+	return streamErr
+}
+
+func init() {
+	getRegionForBucket = getRegionForBucketProd
+	writeToS3 = compressAndWriteBytesToS3
+}

--- a/s3box/s3box.go
+++ b/s3box/s3box.go
@@ -1,0 +1,214 @@
+package s3box
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+const (
+	// DefaultBufferSize is set to 10MB
+	DefaultBufferSize = 10000000
+)
+
+var (
+	// ErrS3BucketRequired signals an s3 bucket wasn't provided
+	ErrS3BucketRequired = fmt.Errorf("An s3 bucket is required to create an s3box.")
+
+	// ErrBoxIsSealed signals an operation which can't occur when a box is sealed.
+	ErrBoxIsSealed = fmt.Errorf("Cannot perform action when box is sealed.")
+
+	// ErrInvalidJSONInput captures when the input data can't be marshalled into JSON.
+	ErrInvalidJSONInput = fmt.Errorf("Only JSON-able inputs are supported for syncing to Redshift.")
+)
+
+// S3Box manages piping data into Redshift. The core idea is to buffer data locally, ship to s3 when too much is buffered, and finally box to Redshift.
+type S3Box struct {
+	// Inheret mutex locking/unlocking
+	sync.Mutex
+
+	// s3Bucket specifies the intermediary bucket before ultimately piping to Redshift. The user should have access to this bucket.
+	s3Bucket string
+
+	// s3Handler manages the piping of data to s3
+	s3Handler *s3.S3
+
+	// bufferSize is the maximum size of data we're willing to buffer before creating an s3 file
+	bufferSize int
+
+	// bufferedData is the data currently buffered in the box. Calling Dump ships this data into s3
+	bufferedData []byte
+
+	// timestamp tracks the time a box was created or reset
+	timestamp time.Time
+
+	// fileNumber indicates the number of s3 files which have currently been created
+	fileNumber int
+
+	// fileLocations stores the s3 files already created
+	fileLocations []string
+
+	// isSealed indicates whether writes are currently allows to the buffer
+	isSealed bool
+}
+
+// NewS3BoxOptions is the expected input for creating a new S3Box
+type NewS3BoxOptions struct {
+	// S3Bucket specifies the intermediary bucket before ultimately piping to Redshift. The user should have access to this bucket
+	S3Bucket string
+
+	// AWSKey is the AWS ACCESS KEY ID
+	AWSKey string
+
+	// AWSPassword is the AWS SECRET ACCESS KEY
+	AWSPassword string
+
+	// AWSToken is the AWS SESSION TOKEN
+	AWSToken string
+
+	// BufferSize is the maximum size of data we're willing to buffer before creating an s3 file
+	BufferSize int
+}
+
+// NewS3Box creates a new S3Box given the input options, but without the requirement of a destination config.
+// Errors occur if there's an invalid input or if there's difficulty setting up an s3 connection.
+func NewS3Box(options NewS3BoxOptions) (*S3Box, error) {
+	// Check for required inputs and a valid destination config
+	if options.S3Bucket == "" {
+		return nil, ErrS3BucketRequired
+	}
+
+	bufferSize := DefaultBufferSize
+	if options.BufferSize > 0 {
+		bufferSize = options.BufferSize
+	}
+
+	// Setup s3 handler and aws configuration. If no creds are explicitly provided, they'll be grabbed from the environment.
+	region, err := getRegionForBucket(options.S3Bucket)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get AWS region for bucket %s: (%s)", options.S3Bucket, err)
+	}
+
+	// If AWS creds were provided use those, otherwise grab them from your environment
+	var awsCreds *credentials.Credentials
+	if options.AWSKey == "" && options.AWSPassword == "" && options.AWSToken == "" {
+		awsCreds = credentials.NewEnvCredentials()
+	} else {
+		awsCreds = credentials.NewStaticCredentials(options.AWSKey, options.AWSPassword, options.AWSToken)
+	}
+	awsConfig := aws.NewConfig().WithRegion(region).WithS3ForcePathStyle(true).WithCredentials(awsCreds)
+	awsSession := session.New()
+
+	return &S3Box{
+		s3Bucket:   options.S3Bucket,
+		timestamp:  time.Now(),
+		s3Handler:  s3.New(awsSession, awsConfig),
+		bufferSize: bufferSize,
+	}, nil
+}
+
+// NextBox gives you a new box, forgetting everything about previously packaged data
+func (sb *S3Box) NextBox() {
+	sb.Lock()
+	sb.timestamp = time.Now()
+	sb.fileNumber = 0
+	sb.fileLocations = []string{}
+	sb.bufferedData = []byte{}
+	sb.isSealed = false
+	sb.Unlock()
+}
+
+// Pack writes bytes into a buffer. Once that buffer hits capacity, the data is output to s3.
+// Any error will leave the buffer unmodified.
+func (sb *S3Box) Pack(data []byte) error {
+	if sb.isSealed {
+		return ErrBoxIsSealed
+	}
+
+	// If the bytes aren't in JSON format, return an error
+	var tempMap map[string]interface{}
+	if err := json.Unmarshal(data, &tempMap); err != nil {
+		return ErrInvalidJSONInput
+	}
+
+	sb.Lock()
+	oldBuffer := sb.bufferedData // If write fails, keep buffered data unchanged
+	data = append(data, '\n')    // Append a new line for text-editor readability
+	sb.bufferedData = append(sb.bufferedData, data...)
+	sb.Unlock()
+
+	// If we're hitting capacity, dump the results to s3.
+	// If shipping to s3 errors, don't modify the buffer.
+	if len(sb.bufferedData) > sb.bufferSize {
+		if err := sb.dumpToS3(); err != nil {
+			sb.Lock()
+			sb.bufferedData = oldBuffer
+			sb.Unlock()
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Seal closes writes and flushes any buffered data to s3. A manifest is then
+// created and uploaded to s3 with the given name.
+func (sb *S3Box) Seal(manifestName string) error {
+	if err := sb.dumpToS3(); err != nil {
+		return err
+	}
+
+	if err := sb.createAndUploadManifest(manifestName); err != nil {
+		return err
+	}
+
+	sb.isSealed = true
+	return nil
+}
+
+// dumpToS3 ships buffered  data to s3 and increments the index with a clean slate of running data
+func (sb *S3Box) dumpToS3() error {
+	if len(sb.bufferedData) == 0 {
+		return nil
+	}
+	fileKey := fmt.Sprintf("%d_%d.json.gz", sb.timestamp.UnixNano(), sb.fileNumber)
+	sb.Lock()
+	defer sb.Unlock()
+	if err := writeToS3(sb.s3Handler, sb.s3Bucket, fileKey, sb.bufferedData); err != nil {
+		return err
+	}
+	sb.fileNumber++
+	sb.bufferedData = []byte{}
+	fileName := fmt.Sprintf("s3://%s/%s", sb.s3Bucket, fileKey)
+	sb.fileLocations = append(sb.fileLocations, fileName)
+	return nil
+}
+
+func (sb *S3Box) createAndUploadManifest(manifestName string) error {
+	type entry struct {
+		URL       string `json:"url"`
+		Mandatory bool   `json:"mandatory"`
+	}
+	type entries struct {
+		Entries []entry `json:"entries"`
+	}
+
+	var manifest entries
+	for _, fileName := range sb.fileLocations {
+		manifest.Entries = append(manifest.Entries, entry{
+			URL:       fileName,
+			Mandatory: true,
+		})
+	}
+
+	manifestBytes, _ := json.Marshal(manifest)
+	log.Printf("Writing manifest to s3://%s/%s\n", sb.s3Bucket, manifestName)
+	return writeToS3(sb.s3Handler, sb.s3Bucket, manifestName, manifestBytes)
+}

--- a/s3box/s3box_test.go
+++ b/s3box/s3box_test.go
@@ -1,0 +1,173 @@
+package s3box
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	s3Bucket     = "test-bucket"
+	awsKey       = "Key"
+	awsPassword  = "Pass"
+	testManifest = "test.manifest"
+)
+
+func getRegionForBucketSuccess(bucket string) (string, error) {
+	return "Success", nil
+}
+
+func getRegionForBucketFail(bucket string) (string, error) {
+	return "", fmt.Errorf("Failed getting bucket location.")
+}
+
+func writeToS3Success(s3Handler *s3.S3, schema, table string, input []byte) error {
+	return nil
+}
+
+func writeToS3Fail(s3Handler *s3.S3, schema, table string, input []byte) error {
+	return fmt.Errorf("Failed writing to s3.")
+}
+
+func TestMain(m *testing.M) {
+	// Assume successful s3 calls by default
+	getRegionForBucket = getRegionForBucketSuccess
+	writeToS3 = writeToS3Success
+
+	os.Exit(m.Run())
+}
+
+func TestSuccessfulBoxCreation(t *testing.T) {
+	assert := assert.New(t)
+	// We should be able to successfully create a box with both complete and incomplete configurations.
+	_, err := NewS3Box(NewS3BoxOptions{
+		S3Bucket:    s3Bucket,
+		AWSKey:      awsKey,
+		AWSPassword: awsPassword,
+	})
+	assert.NoError(err)
+}
+
+func TestUnsuccessfulBoxCreation(t *testing.T) {
+	assert := assert.New(t)
+
+	// Error if we include a config without either a schema or table
+	_, err := NewS3Box(NewS3BoxOptions{})
+	assert.Equal(err, ErrS3BucketRequired)
+}
+
+func TestValidPacks(t *testing.T) {
+	assert := assert.New(t)
+	rp, err := NewS3Box(NewS3BoxOptions{
+		S3Bucket:    s3Bucket,
+		AWSKey:      awsKey,
+		AWSPassword: awsPassword,
+	})
+	assert.NoError(err)
+
+	data1, _ := json.Marshal(map[string]interface{}{"Table": "row"})
+	assert.NoError(rp.Pack(data1))
+	assert.Equal(len(rp.bufferedData), len(data1)+1) // Account for the appended new line character
+
+	rp, err = NewS3Box(NewS3BoxOptions{
+		S3Bucket:    s3Bucket,
+		AWSKey:      awsKey,
+		AWSPassword: awsPassword,
+	})
+	assert.NoError(err)
+
+	data2, _ := json.Marshal(map[string]interface{}{"time": time.Now(), "id": "1234"})
+	assert.NoError(rp.Pack(data2))
+	assert.Equal(len(rp.bufferedData), len(data2)+1) // Account for the appended new line character
+}
+
+func TestCorrectNumberOfS3Writes(t *testing.T) {
+	assert := assert.New(t)
+	data, _ := json.Marshal(map[string]interface{}{"time": time.Now(), "id": "1234"})
+	rp, err := NewS3Box(NewS3BoxOptions{
+		S3Bucket:    s3Bucket,
+		AWSKey:      awsKey,
+		AWSPassword: awsPassword,
+		BufferSize:  len(data), // This is chosen such that each pack will overflow the buffer and "write" to s3
+	})
+	assert.NoError(err)
+
+	nFiles := 10
+	for i := 0; i < nFiles; i++ {
+		assert.NoError(rp.Pack(data))
+	}
+	assert.Equal(rp.fileNumber, nFiles)
+	assert.Equal(len(rp.fileLocations), nFiles)
+}
+
+func TestInvalidPacks(t *testing.T) {
+	assert := assert.New(t)
+	rp, err := NewS3Box(NewS3BoxOptions{
+		S3Bucket:    s3Bucket,
+		AWSKey:      awsKey,
+		AWSPassword: awsPassword,
+	})
+	assert.NoError(err)
+
+	stringData := []byte("Some string")
+	assert.Error(rp.Pack(stringData))
+
+	jsonArray := []byte("[{\"k1\": \"v1\"},{\"k2\":\"v2\"}\"]")
+	assert.Equal(rp.Pack(jsonArray), ErrInvalidJSONInput)
+}
+
+func TestBufferedDataRemainsUnchangedOnPackErrors(t *testing.T) {
+	assert := assert.New(t)
+	data, _ := json.Marshal(map[string]interface{}{"time": time.Now(), "id": "1234"})
+
+	// r := mux.NewRouter()
+	// r.HandleFunc("/", fastHandler).Methods("POST")
+	// httptest.NewServer(r)
+	rp, err := NewS3Box(NewS3BoxOptions{
+		S3Bucket:    s3Bucket,
+		AWSKey:      awsKey,
+		AWSPassword: awsPassword,
+		BufferSize:  len(data) + 2,
+	})
+	assert.NoError(err)
+
+	assert.NoError(rp.Pack(data))
+	assert.Equal(len(rp.bufferedData), len(data)+1)
+
+	invalidData := []byte("Some string")
+	assert.Error(rp.Pack(invalidData))
+	assert.Equal(len(rp.bufferedData), len(data)+1)
+	assert.Equal(rp.fileNumber, 0)
+	assert.Equal(len(rp.fileLocations), 0)
+
+	// Since we'll be packing data larger than the buffer size, this will trigger
+	// a write. And since this write will fail the pack will fail and the data
+	// should remain unchanged.
+	writeToS3 = writeToS3Fail
+	defer func() {
+		writeToS3 = writeToS3Success
+	}()
+	assert.Error(rp.Pack(data))
+	assert.Equal(len(rp.bufferedData), len(data)+1)
+	assert.Equal(rp.fileNumber, 0)
+	assert.Equal(len(rp.fileLocations), 0)
+}
+
+func TestNoWritesAfterSeal(t *testing.T) {
+	assert := assert.New(t)
+	rp, err := NewS3Box(NewS3BoxOptions{
+		S3Bucket:    s3Bucket,
+		AWSKey:      awsKey,
+		AWSPassword: awsPassword,
+	})
+	assert.NoError(err)
+
+	assert.NoError(rp.Seal(testManifest))
+	data, _ := json.Marshal(map[string]interface{}{"time": time.Now(), "id": "1234"})
+	assert.Equal(rp.Pack(data), ErrBoxIsSealed)
+}


### PR DESCRIPTION
The vision of redbox will be to completely decouple the `s3-to-redshift` dependency, as well as decouple streaming data to s3 versus streaming data to Redshift.

Here we leave the base directory unchanged, but add an "S3Box" which has `Pack` and `Seal` methods for efficiently streaming data to s3.

In the future we'll:
1. Create a RedshiftSender interface which simply has the signature "func Send(manifest string) error"
2. Add a default RedshiftSender
3. Restructure Redbox to utilize the s3Box and remove the `s3-to-redshift` dependency in favor of an optional input for a RedshiftSender.