### PR TITLE
Don't gzip manifest files

### DIFF
--- a/s3box/s3box.go
+++ b/s3box/s3box.go
@@ -179,7 +179,7 @@ func (sb *S3Box) dumpToS3() error {
 	fileKey := fmt.Sprintf("%d_%d.json.gz", sb.timestamp.UnixNano(), sb.fileNumber)
 	sb.Lock()
 	defer sb.Unlock()
-	if err := writeToS3(sb.s3Handler, sb.s3Bucket, fileKey, sb.bufferedData); err != nil {
+	if err := writeToS3(sb.s3Handler, sb.s3Bucket, fileKey, sb.bufferedData, true); err != nil {
 		return err
 	}
 	sb.fileNumber++
@@ -223,7 +223,7 @@ func (sb *S3Box) CreateManifests(manifestSlug string, nManifests int) ([]string,
 		manifestBytes, _ := json.Marshal(manifest)
 		manifestName := fmt.Sprintf("%s_%d.manifest", manifestSlug, i)
 		manifestLocations[i] = manifestName
-		if err := writeToS3(sb.s3Handler, sb.s3Bucket, manifestName, manifestBytes); err != nil {
+		if err := writeToS3(sb.s3Handler, sb.s3Bucket, manifestName, manifestBytes, false); err != nil {
 			return nil, err
 		}
 		log.Printf("Wrote manifest to s3://%s/%s\n", sb.s3Bucket, manifestName)

--- a/s3box/s3box_test.go
+++ b/s3box/s3box_test.go
@@ -25,11 +25,11 @@ func getRegionForBucketFail(bucket string) (string, error) {
 	return "", fmt.Errorf("Failed getting bucket location.")
 }
 
-func writeToS3Success(s3Handler *s3.S3, schema, table string, input []byte) error {
+func writeToS3Success(s3Handler *s3.S3, schema, table string, input []byte, gzip bool) error {
 	return nil
 }
 
-func writeToS3Fail(s3Handler *s3.S3, schema, table string, input []byte) error {
+func writeToS3Fail(s3Handler *s3.S3, schema, table string, input []byte, gzip bool) error {
 	return fmt.Errorf("Failed writing to s3.")
 }
 


### PR DESCRIPTION
Manifest files were being gzipped to s3, however Redshift only accepts unencrypted manifests.