### PR TITLE
Tweak comments, README, and private method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ type NewRedboxOptions struct {
 - BufferSize sets the file sizes uploaded s3. This is useful for memory management and `2*BufferSize` should be comfortably available at all times. AWS recommends this lie between 10MB and 1GB.
 - NManifests will not likely need to be touched. To prevent connection timeouts for extremely large data transports, NManifests will instruct how many manifests to split the data across. A default of 4 should be sufficient for a large number of use cases.
 
+**Note:** The AWS credentials must have both read and write access to the S3 bucket.
 
 ## Redbox - The Methods
 
@@ -62,6 +63,7 @@ Currently Pack is a single row operation which *only* accepts JSONifiable inputs
 ### Ship() ([]string, error)
 
 Ship commits all packed data to Redshift. If "Truncate" is provided in the configuration, the destination table will first be deleted.
+The return is a list of manifests pointing to each data file generated, see [the AWS documentation](http://docs.aws.amazon.com/redshift/latest/dg/loading-data-files-using-manifest.html).
 Ship is transactional, meaning any returned error implies the destination table has been left unchanged.
 
 ## Example

--- a/redbox_test.go
+++ b/redbox_test.go
@@ -69,7 +69,7 @@ func TestSuccessfulJSONPack(t *testing.T) {
 	s3Box := &MockSuccessS3Box{}
 	redshift, mock, err := sqlmock.New()
 	assert.NoError(err)
-	redbox := newRedboxGivenS3BoxAndRedshift(testOptions, s3Box, redshift)
+	redbox := newRedboxInjection(testOptions, s3Box, redshift)
 
 	data, _ := json.Marshal(map[string]interface{}{"key": "value"})
 	assert.NoError(redbox.Pack(data))
@@ -81,7 +81,7 @@ func TestUnsuccessfulCSVPack(t *testing.T) {
 	s3Box := &MockSuccessS3Box{}
 	redshift, mock, err := sqlmock.New()
 	assert.NoError(err)
-	redbox := newRedboxGivenS3BoxAndRedshift(testOptions, s3Box, redshift)
+	redbox := newRedboxInjection(testOptions, s3Box, redshift)
 
 	data := []byte("d1,d2")
 	assert.Equal(redbox.Pack(data), errInvalidJSONInput)
@@ -96,7 +96,7 @@ func TestCorrectDBCallsOnSendWithTruncate(t *testing.T) {
 	options := testOptions
 	options.Truncate = true
 	options.NManifests = 5
-	redbox := newRedboxGivenS3BoxAndRedshift(options, s3Box, redshift)
+	redbox := newRedboxInjection(options, s3Box, redshift)
 
 	// Set expected commands for mocked SQL client
 	mock.ExpectBegin()
@@ -126,7 +126,7 @@ func TestCorrectDBCallsOnSendWithoutTruncate(t *testing.T) {
 	assert.NoError(err)
 	options := testOptions
 	options.NManifests = 5
-	redbox := newRedboxGivenS3BoxAndRedshift(options, s3Box, redshift)
+	redbox := newRedboxInjection(options, s3Box, redshift)
 
 	// Set expected commands for mocked SQL client
 	mock.ExpectBegin()
@@ -152,7 +152,7 @@ func TestRollbackOnError(t *testing.T) {
 	assert.NoError(err)
 	options := testOptions
 	options.NManifests = 5
-	redbox := newRedboxGivenS3BoxAndRedshift(options, s3Box, redshift)
+	redbox := newRedboxInjection(options, s3Box, redshift)
 
 	// Set expected commands for mocked SQL client
 	mock.ExpectBegin()
@@ -178,7 +178,7 @@ func TestNoActionWithNoDataWrites(t *testing.T) {
 	assert.NoError(err)
 	options := testOptions
 	options.NManifests = 0
-	redbox := newRedboxGivenS3BoxAndRedshift(options, s3Box, redshift)
+	redbox := newRedboxInjection(options, s3Box, redshift)
 
 	manifests, err := redbox.Ship()
 	assert.Nil(manifests)
@@ -193,7 +193,7 @@ func TestNoActionsAllowedDuringOrAfterSuccessfulSend(t *testing.T) {
 	assert.NoError(err)
 	options := testOptions
 	options.NManifests = 5
-	redbox := newRedboxGivenS3BoxAndRedshift(options, s3Box, redshift)
+	redbox := newRedboxInjection(options, s3Box, redshift)
 
 	// Set expected commands for mocked SQL client
 	mock.ExpectBegin()

--- a/s3box/s3box.go
+++ b/s3box/s3box.go
@@ -159,12 +159,12 @@ func (sb *S3Box) Pack(data []byte) error {
 // input number of manifests. If nManifests is greater than the number of generated
 // s3 files, you'll only receive manifests back point
 func (sb *S3Box) CreateManifests(manifestSlug string, nManifests int) ([]string, error) {
+	sb.mt.Lock()
+	defer sb.mt.Unlock()
+
 	if err := sb.dumpToS3(); err != nil {
 		return nil, err
 	}
-
-	sb.mt.Lock()
-	defer sb.mt.Unlock()
 
 	type entry struct {
 		URL       string `json:"url"`

--- a/s3box/s3box.go
+++ b/s3box/s3box.go
@@ -159,15 +159,12 @@ func (sb *S3Box) Pack(data []byte) error {
 // input number of manifests. If nManifests is greater than the number of generated
 // s3 files, you'll only receive manifests back point
 func (sb *S3Box) CreateManifests(manifestSlug string, nManifests int) ([]string, error) {
-	sb.Lock()
-	defer sb.Unlock()
-	if sb.isShipped {
-		return nil, errBoxIsShipped
-	}
-
 	if err := sb.dumpToS3(); err != nil {
 		return nil, err
 	}
+
+	sb.Lock()
+	defer sb.Unlock()
 
 	type entry struct {
 		URL       string `json:"url"`

--- a/s3box/s3box.go
+++ b/s3box/s3box.go
@@ -29,7 +29,7 @@ var (
 // S3Box manages piping data into S3. The mechanics are to buffer data locally, ship to s3 when too much is buffered, and finally create manifests pointing to the data files.
 type S3Box struct {
 	// Inheret mutex locking/unlocking
-	sync.Mutex
+	mt sync.Mutex
 
 	// s3Bucket specifies the intermediary bucket before ultimately piping to Redshift. The user should have access to this bucket.
 	s3Bucket string
@@ -137,8 +137,8 @@ func (sb *S3Box) Pack(data []byte) error {
 		return errBoxIsShipped
 	}
 
-	sb.Lock()
-	defer sb.Unlock()
+	sb.mt.Lock()
+	defer sb.mt.Unlock()
 	oldBuffer := sb.bufferedData // If write fails, keep buffered data unchanged
 	data = append(data, '\n')    // Append a new line for text-editor readability
 	sb.bufferedData = append(sb.bufferedData, data...)
@@ -163,8 +163,8 @@ func (sb *S3Box) CreateManifests(manifestSlug string, nManifests int) ([]string,
 		return nil, err
 	}
 
-	sb.Lock()
-	defer sb.Unlock()
+	sb.mt.Lock()
+	defer sb.mt.Unlock()
 
 	type entry struct {
 		URL       string `json:"url"`

--- a/s3box/s3box_test.go
+++ b/s3box/s3box_test.go
@@ -168,25 +168,6 @@ func TestNoWritesAfterManifestCreation(t *testing.T) {
 	assert.Equal(sb.Pack(data), errBoxIsShipped)
 }
 
-func TestCantCreateManifestsWhenBoxHasBeenShipped(t *testing.T) {
-	assert := assert.New(t)
-	sb, err := NewS3Box(NewS3BoxOptions{
-		S3Bucket:    s3Bucket,
-		AWSKey:      awsKey,
-		AWSPassword: awsPassword,
-	})
-	assert.NoError(err)
-
-	data, _ := json.Marshal(map[string]interface{}{"time": time.Now(), "id": "1234"})
-	assert.NoError(sb.Pack(data))
-
-	_, err = sb.CreateManifests("test", 1)
-	assert.NoError(err)
-
-	_, err = sb.CreateManifests("test", 1)
-	assert.Equal(err, errBoxIsShipped)
-}
-
 func TestCreatesCorrectNumberOfManifests(t *testing.T) {
 	assert := assert.New(t)
 	sb, err := NewS3Box(NewS3BoxOptions{


### PR DESCRIPTION
Make the following changes:
- Update comments
- Mutexes are no longer inherited publicly
- Rename newRedboxWithS3BoxAndRedshift -> newRedboxInjection
- CreateManifests can now be called multiple times without error 