### PR TITLE
Tweaks

### DIFF
--- a/redbox.go
+++ b/redbox.go
@@ -148,6 +148,7 @@ func NewRedbox(options RedboxOptions) (*Redbox, error) {
 }
 
 // Pack writes a single row of bytes. Currently accepts JSON inputs.
+// Pack is concurrency safe.
 func (rb *Redbox) Pack(row []byte) error {
 	if rb.isShipped() {
 		return errBoxShipped

--- a/s3box/s3box.go
+++ b/s3box/s3box.go
@@ -209,7 +209,7 @@ func (sb *S3Box) dumpToS3() error {
 		return nil
 	}
 	fileNumber := len(sb.fileLocations)
-	fileKey := fmt.Sprintf("%d_%d.json.gz", sb.timestamp.UnixNano(), fileNumber)
+	fileKey := fmt.Sprintf("%d_%d.gz", sb.timestamp.UnixNano(), fileNumber)
 	if err := writeToS3(sb.s3Handler, sb.s3Bucket, fileKey, sb.bufferedData, true); err != nil {
 		return err
 	}


### PR DESCRIPTION
- Better Pack comment
- S3Box no longer specifically writes files as `.json.gz`, rather as `.gz`