### PR TITLE
S3box restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ type RedshiftConfiguration struct {
 }
 ```
 
-### RedboxOptions
+### Options
 
 ```
-type RedboxOptions struct {
+type Options struct {
   // Required inputs
   Schema                string
   Table                 string
@@ -79,7 +79,7 @@ Ship is transactional, meaning any returned error implies the destination table 
 ```
 func SomeJob() {
   // Setup. AWS creds determined from environment.
-  redbox, err := NewRedbox(RedboxOptions{
+  redbox, err := NewRedbox(Options{
     Schema:   "schema",
     Table:    "table",
     S3Bucket: "bucket-with-user-access",

--- a/redbox.go
+++ b/redbox.go
@@ -29,10 +29,10 @@ type Redbox struct {
 	mt sync.Mutex
 
 	// o holds the options used for configurating the Redbox instance
-	o RedboxOptions
+	o Options
 
 	// s3Box manages the transport of data to Redshift
-	s3Box s3box.S3BoxAPI
+	s3Box s3box.API
 
 	// redshift is the direct redshift connection
 	redshift *sql.DB
@@ -44,8 +44,8 @@ type Redbox struct {
 	shipped bool
 }
 
-// RedboxOptions specifies the configuration for a new Redbox
-type RedboxOptions struct {
+// Options specifies the configuration for a new Redbox
+type Options struct {
 	// Schema is the destination Redshift table schema
 	Schema string
 
@@ -93,7 +93,7 @@ type RedboxOptions struct {
 }
 
 // newRedboxInjection returns an Redbox with given input s3Box and redshift inputs.
-func newRedboxInjection(options RedboxOptions, s3Box s3box.S3BoxAPI, redshift *sql.DB) *Redbox {
+func newRedboxInjection(options Options, s3Box s3box.API, redshift *sql.DB) *Redbox {
 	return &Redbox{
 		o:        options,
 		s3Box:    s3Box,
@@ -104,7 +104,7 @@ func newRedboxInjection(options RedboxOptions, s3Box s3box.S3BoxAPI, redshift *s
 // NewRedbox creates a new Redbox given the input options.
 // Errors occur if there's an invalid input or if there's
 // difficulty setting up either an s3 or redshift connection.
-func NewRedbox(options RedboxOptions) (*Redbox, error) {
+func NewRedbox(options Options) (*Redbox, error) {
 	if options.Schema == "" || options.Table == "" || options.S3Bucket == "" {
 		return nil, errIncompleteArgs
 	}
@@ -124,7 +124,7 @@ func NewRedbox(options RedboxOptions) (*Redbox, error) {
 		options.S3Region = s3Region
 	}
 
-	s3Box, err := s3box.NewS3Box(s3box.NewS3BoxOptions{
+	s3Box, err := s3box.NewS3Box(s3box.Options{
 		S3Bucket:    options.S3Bucket,
 		S3Region:    options.S3Region,
 		AWSKey:      options.AWSKey,

--- a/redbox_interface.go
+++ b/redbox_interface.go
@@ -1,0 +1,7 @@
+package redbox
+
+// API establishes the Redbox interface
+type API interface {
+	Pack(data []byte) error
+	Ship() ([]string, error)
+}

--- a/redbox_test.go
+++ b/redbox_test.go
@@ -20,7 +20,7 @@ var (
 	awsPassword      = "secret"
 	testManifestSlug = "slug"
 
-	testOptions = RedboxOptions{
+	testOptions = Options{
 		Schema:      schema,
 		Table:       table,
 		S3Bucket:    s3Bucket,

--- a/s3box/README.md
+++ b/s3box/README.md
@@ -10,9 +10,9 @@ See both below and the [the godocs](https://godoc.org/github.com/cgclever/redbox
 
 ### NewS3Box
 
-`func NewS3Box(options NewS3BoxOptions) (*S3Box, error)`
+`func NewS3Box(options Options) (*S3Box, error)`
 
-### NewS3BoxOptions
+### Options
 
 ```
 type NewS3oxOptions struct {
@@ -67,7 +67,7 @@ type Row struct {
 
 func SomeJob() {
   // Setup
-  sb, err := s3box.NewS3Box(s3box.NewS3BoxOptions{
+  sb, err := s3box.NewS3Box(s3box.Options{
     S3Bucket: "bucket-with-user-access",
     AWSKey: yourAWSAccessKeyID,
     AWSPassword: yourAWSSecretAccessKey,

--- a/s3box/s3box.go
+++ b/s3box/s3box.go
@@ -20,10 +20,10 @@ const (
 
 var (
 	// errS3BucketRequired signals an s3 bucket wasn't provided
-	errS3BucketRequired = fmt.Errorf("An s3 bucket is required to create an s3box.")
+	errS3BucketRequired = fmt.Errorf("an s3 bucket is required to create an s3box")
 
 	// ErrBoxIsSealed signals an operation which can't occur when a box is sealed.
-	errBoxIsShipped = fmt.Errorf("Cannot perform action after creating manifests as box has been shipped.")
+	errBoxIsShipped = fmt.Errorf("cannot perform action after creating manifests as box has been shipped")
 )
 
 // S3Box manages piping data into S3. The mechanics are to buffer data locally, ship to s3 when too much is buffered, and finally create manifests pointing to the data files.
@@ -32,7 +32,7 @@ type S3Box struct {
 	mt sync.Mutex
 
 	// o stores the input options pointing
-	o NewS3BoxOptions
+	o Options
 
 	// s3Handler manages the piping of data to s3
 	s3Handler *s3.S3
@@ -51,10 +51,10 @@ type S3Box struct {
 	isShipped bool
 }
 
-// NewS3BoxOptions is the expected input for creating a new S3Box.
+// Options is the expected input for creating a new S3Box.
 // Currently only an S3Bucket is required. If AWS vars aren't explicitly provided, they'll
 // be pulled from your environment.
-type NewS3BoxOptions struct {
+type Options struct {
 	// S3Bucket is the destination s3 bucket.
 	// This is required.
 	S3Bucket string
@@ -85,7 +85,7 @@ type NewS3BoxOptions struct {
 
 // NewS3Box creates a new S3Box given the input options.
 // Errors occur if there's an invalid input or if there's difficulty setting up an s3 connection.
-func NewS3Box(options NewS3BoxOptions) (*S3Box, error) {
+func NewS3Box(options Options) (*S3Box, error) {
 	// Check for required inputs and a valid destination config
 	if options.S3Bucket == "" {
 		return nil, errS3BucketRequired

--- a/s3box/s3box_interface.go
+++ b/s3box/s3box_interface.go
@@ -1,7 +1,7 @@
 package s3box
 
-// S3BoxAPI establishes an S3Box interface
-type S3BoxAPI interface {
+// API establishes an S3Box interface
+type API interface {
 	Pack(data []byte) error
 	CreateManifests(manifestSlug string, nManifests int) ([]string, error)
 }

--- a/s3box/s3box_test.go
+++ b/s3box/s3box_test.go
@@ -23,7 +23,7 @@ func getRegionForBucketSuccess(bucket string) (string, error) {
 }
 
 func getRegionForBucketFail(bucket string) (string, error) {
-	return "", fmt.Errorf("Failed getting bucket location.")
+	return "", fmt.Errorf("failed getting bucket location")
 }
 
 func writeToS3Success(s3Handler *s3.S3, schema, table string, input []byte, gzip bool) error {
@@ -31,7 +31,7 @@ func writeToS3Success(s3Handler *s3.S3, schema, table string, input []byte, gzip
 }
 
 func writeToS3Fail(s3Handler *s3.S3, schema, table string, input []byte, gzip bool) error {
-	return fmt.Errorf("Failed writing to s3.")
+	return fmt.Errorf("failed writing to s3")
 }
 
 func TestMain(m *testing.M) {
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 func TestSuccessfulBoxCreation(t *testing.T) {
 	assert := assert.New(t)
 	// We should be able to successfully create a box with both complete and incomplete configurations.
-	_, err := NewS3Box(NewS3BoxOptions{
+	_, err := NewS3Box(Options{
 		S3Bucket:    s3Bucket,
 		AWSKey:      awsKey,
 		AWSPassword: awsPassword,
@@ -62,7 +62,7 @@ func TestDontAttemptToGetRegionIfProvided(t *testing.T) {
 
 	assert := assert.New(t)
 	// We should be able to successfully create a box with both complete and incomplete configurations.
-	_, err := NewS3Box(NewS3BoxOptions{
+	_, err := NewS3Box(Options{
 		S3Bucket:    s3Bucket,
 		S3Region:    s3Region,
 		AWSKey:      awsKey,
@@ -75,13 +75,13 @@ func TestUnsuccessfulBoxCreation(t *testing.T) {
 	assert := assert.New(t)
 
 	// Error if we include a config without either a schema or table
-	_, err := NewS3Box(NewS3BoxOptions{})
+	_, err := NewS3Box(Options{})
 	assert.Equal(err, errS3BucketRequired)
 }
 
 func TestValidPacks(t *testing.T) {
 	assert := assert.New(t)
-	sb, err := NewS3Box(NewS3BoxOptions{
+	sb, err := NewS3Box(Options{
 		S3Bucket:    s3Bucket,
 		AWSKey:      awsKey,
 		AWSPassword: awsPassword,
@@ -92,7 +92,7 @@ func TestValidPacks(t *testing.T) {
 	assert.NoError(sb.Pack(data1))
 	assert.Equal(len(sb.bufferedData), len(data1)+1) // Account for the appended new line character
 
-	sb, err = NewS3Box(NewS3BoxOptions{
+	sb, err = NewS3Box(Options{
 		S3Bucket:    s3Bucket,
 		AWSKey:      awsKey,
 		AWSPassword: awsPassword,
@@ -107,7 +107,7 @@ func TestValidPacks(t *testing.T) {
 func TestCorrectNumberOfS3Writes(t *testing.T) {
 	assert := assert.New(t)
 	data, _ := json.Marshal(map[string]interface{}{"time": time.Now(), "id": "1234"})
-	sb, err := NewS3Box(NewS3BoxOptions{
+	sb, err := NewS3Box(Options{
 		S3Bucket:    s3Bucket,
 		AWSKey:      awsKey,
 		AWSPassword: awsPassword,
@@ -129,7 +129,7 @@ func TestBufferedDataRemainsUnchangedOnPackErrors(t *testing.T) {
 	// r := mux.NewRouter()
 	// r.HandleFunc("/", fastHandler).Methods("POST")
 	// httptest.NewServer(r)
-	sb, err := NewS3Box(NewS3BoxOptions{
+	sb, err := NewS3Box(Options{
 		S3Bucket:    s3Bucket,
 		AWSKey:      awsKey,
 		AWSPassword: awsPassword,
@@ -154,7 +154,7 @@ func TestBufferedDataRemainsUnchangedOnPackErrors(t *testing.T) {
 
 func TestNoWritesAfterManifestCreation(t *testing.T) {
 	assert := assert.New(t)
-	sb, err := NewS3Box(NewS3BoxOptions{
+	sb, err := NewS3Box(Options{
 		S3Bucket:    s3Bucket,
 		AWSKey:      awsKey,
 		AWSPassword: awsPassword,
@@ -170,7 +170,7 @@ func TestNoWritesAfterManifestCreation(t *testing.T) {
 
 func TestCreatesCorrectNumberOfManifests(t *testing.T) {
 	assert := assert.New(t)
-	sb, err := NewS3Box(NewS3BoxOptions{
+	sb, err := NewS3Box(Options{
 		S3Bucket:    s3Bucket,
 		AWSKey:      awsKey,
 		AWSPassword: awsPassword,


### PR DESCRIPTION
- Fix linting errors, including `NewS3BoxOptions -> Options`
- S3Box stores options instead of separating out variables
- Add `API` struct for `redbox`